### PR TITLE
meson.build: Remove libunwind dependency

### DIFF
--- a/.github/ci/install-deps-deb.sh
+++ b/.github/ci/install-deps-deb.sh
@@ -26,6 +26,5 @@ eatmydata apt-get install -yq \
         libgtkd-3-dev \
         librsvg2-dev \
         libsecret-1-dev \
-        libunwind-dev \
         libvted-3-dev \
         po4a

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,6 @@ jobs:
                 libpango1.0-dev \
                 librsvg2-dev \
                 libsecret-1-dev \
-                libunwind-dev \
                 libgtksourceview-3.0-dev \
                 libpeas-dev \
                 libvte-2.91-dev

--- a/meson.build
+++ b/meson.build
@@ -99,7 +99,6 @@ sources_dir = include_directories('source/')
 gtkd_dep = dependency('gtkd-3', version: '>=3.8.5')
 vted_dep = dependency('vted-3', version: '>=3.8.5')
 xlib_dep = dependency('x11')
-libunwind_dep = dependency('libunwind')
 libsecret_dep = dependency('libsecret-1', required: false)
 
 subdir('po')
@@ -112,7 +111,6 @@ executable('tilix',
     dependencies : [gtkd_dep,
                     vted_dep,
                     xlib_dep,
-                    libunwind_dep,
                     libsecret_dep],
     d_args: d_extra_args,
     d_module_versions: ['StdLoggerDisableTrace'],


### PR DESCRIPTION
The dependency has been added in
6923ee9194523526a9d54d7be8ddcf51847b3c72 in the context of https://github.com/gnunn1/tilix/issues/1502#issuecomment-425723007 which was trying to diagnose issues with building using meson.

The commit has been added so others can use it as a starting point but it has never been removed. The dub configuration doesn't add it as a dependency as well.

Additionally update CI not to install it.