### PR TITLE
meson.build: add `-allinst` when compiling, #2210

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,12 +5,17 @@ project(
     meson_version: '>= 0.56'
 )
 
+# As a workaround for https://issues.dlang.org/show_bug.cgi?id=20668
+# add -allinst
 compiler = meson.get_compiler('d')
 if compiler.get_id() == 'llvm'
-  d_extra_args = ['-vcolumns']
+  d_extra_args = ['-allinst', '-vcolumns']
   d_link_args = []
-else
-  d_extra_args = []
+elif compiler.get_id() == 'dmd'
+  d_extra_args = ['-allinst']
+  d_link_args = []
+elif compiler.get_id() == 'gcc'
+  d_extra_args = ['-fall-instantiations']
   d_link_args = []
 endif
 


### PR DESCRIPTION
This is needed to work around a bug in dmd regarding template emissions.

Bug: https://github.com/gnunn1/tilix/issues/2210
Bug: https://issues.dlang.org/show_bug.cgi?id=20668